### PR TITLE
Added option for positional arguments

### DIFF
--- a/pyapt/pyapt.py
+++ b/pyapt/pyapt.py
@@ -136,7 +136,7 @@ def write_submit_scripts(task, task_id, parallel_args, n_jobs, task_dir,
                 arg_string = ''
                 for arg, value in sorted(parallel_args[k].items()):
                     if '_POS' in arg:
-                        arg_string += '{} '.format(value)
+                        arg_string += '\'{}\' '.format(value)
                     elif value is None:
                         arg_string += '--{} '.format(arg)
                     else:

--- a/pyapt/pyapt.py
+++ b/pyapt/pyapt.py
@@ -134,12 +134,13 @@ def write_submit_scripts(task, task_id, parallel_args, n_jobs, task_dir,
             # Write python command(s).
             for k in range(start_instance, end_instance):
                 arg_string = ''
-                for arg in parallel_args[k]:
-                    if parallel_args[k][arg] is None:
+                for arg, value in sorted(parallel_args[k].items()):
+                    if '_POS' in arg:
+                        arg_string += '{} '.format(value)
+                    elif value is None:
                         arg_string += '--{} '.format(arg)
                     else:
-                        arg_string += '--{} \'{}\' '.format(
-                            arg, parallel_args[k][arg])
+                        arg_string += '--{} \'{}\' '.format(arg, value)
 
                 pbs_file.write('python {} {} >> {} \n'.format(
                     task, arg_string, report_file))


### PR DESCRIPTION
Added positional argument support, if you want to launch commands such as:
`python test.py foo bar`

Just write down {'_POS0': 'foo', '_POS1': 'bar'} in your variables to pass for PyAPT.